### PR TITLE
Add minimal table styling

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -612,6 +612,15 @@ dl.param-type {
   z-index: 1;
 }
 
+table {
+  border-collapse: collapse;
+}
+
+table tbody td {
+  border-top: 1px solid hsl(207, 10%, 86%);
+  padding: 5px;
+}
+
 @media only screen and (min-width: 320px) and (max-width: 680px) {
   body {
     overflow-x: hidden;


### PR DESCRIPTION
Without table styling:

<img width="801" alt="screen shot 2016-06-15 at 10 24 50 am" src="https://cloud.githubusercontent.com/assets/2916945/16086017/a6add62c-32e3-11e6-8fb6-4d55ca28d019.png">

With table styling:

<img width="801" alt="screen shot 2016-06-15 at 10 20 11 am" src="https://cloud.githubusercontent.com/assets/2916945/16086025/b0147d24-32e3-11e6-94cb-6cfc6a980192.png">
