### PR TITLE
Update deprecation styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/braintree/jsdoc-template",
   "devDependencies": {
     "eslint": "^2.13.1",
-    "eslint-config-braintree": "^1.0.2"
+    "eslint-config-braintree": "^1.0.2",
+    "taffydb": "^2.7.3"
   }
 }

--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -624,6 +624,10 @@ dl.param-type {
 
 /* tag source style */
 
+.tag-deprecated {
+  padding-right: 5px;
+}
+
 .tag-source {
     border-bottom: 1px solid rgba(28, 160, 224, 0.35);
 }

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -79,6 +79,7 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
             if (data.deprecated === true) { ?><dd class="yes-def tag-deprecated"><ul class="dummy"><li>Yes</li></ul></dd><?js }
             else { ?><dd><ul class="dummy"><li><?js= data.deprecated ?></li></ul></dd><?js }
         ?>
+        <br>
     <?js } ?>
 
     <?js if (data.author && author.length) {?>


### PR DESCRIPTION
Cleans up deprecation styling:
<img width="686" alt="screen shot 2017-02-09 at 10 59 37 am" src="https://cloud.githubusercontent.com/assets/7514489/22794112/94a64564-eeb7-11e6-8fe9-5b3394b007f3.png">
 
I'd be a fan of making deprecation more obvious in the future, but that'll require a lil more thought.

Also adds a missing dev dependency.