### PR TITLE
Remove max-width from sections, headers, and paragraphs

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -87,10 +87,6 @@ p, ul, ol, blockquote {
     margin-bottom: 1em;
 }
 
-p {
-    max-width: 800px;
-}
-
 h1, h2, h3, h4, h5, h6 {
     color: #706d77;
     font-weight: 500;
@@ -216,12 +212,10 @@ tt, code, kbd, samp {
 
 header {
     display: block;
-    max-width: 1100px;
 }
 
 section {
     display: block;
-    max-width: 1100px;
     background-color: #fff;
 }
 


### PR DESCRIPTION
Unfortunately, we've got a couple nested tables that got very unreadable with the max-width on sections. I think it looks okay without one, but I could be convinced just to make it a little bigger.

This also fixes the weirdness on the landing page where code snippets were larger than paragraphs. 