### PR TITLE
Increase section max-width to fit one nested table

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -557,6 +557,10 @@ footer {
     user-select: text;
 }
 
+.readme .prettyprint {
+   max-width: 800px;
+}
+
 .params, .props {
     border-spacing: 0;
     border: 1px solid #ddd;

--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -216,12 +216,12 @@ tt, code, kbd, samp {
 
 header {
     display: block;
-    max-width: 1100px;
+    max-width: 1400px;
 }
 
 section {
     display: block;
-    max-width: 1100px;
+    max-width: 1400px;
     background-color: #fff;
 }
 


### PR DESCRIPTION
Sections now fit one nested table before cutting off the text and requiring horizontal scrolling. Not a full fix for the tables, but a lil improvement.

![screen shot 2017-07-24 at 11 14 26 am](https://user-images.githubusercontent.com/7514489/28533261-127162cc-7062-11e7-9cba-1b82d864e53a.png)
![screen shot 2017-07-24 at 11 15 26 am](https://user-images.githubusercontent.com/7514489/28533260-126bd1f4-7062-11e7-8944-35acc54b9557.png)
