### PR TITLE
Add anchor tags to examples

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -938,6 +938,11 @@ input.search-input:focus {
   padding-top: 2px;
 }
 
+.example-container .link-icon {
+  margin-top: -6px;
+}
+
+.example-container:hover .link-icon,
 .name-container:hover .link-icon {
   opacity: .5;
 }

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -116,6 +116,13 @@
 } ?>
 
 <?js if (data.examples && examples.length) { ?>
-  <h5>Example<?js= examples.length > 1? 's':'' ?></h5>
-  <?js= this.partial('examples.tmpl', examples) ?>
+  <div class="example-container">
+    <a class="link-icon" href="<?js= '#' + data.name + '-examples' ?>">
+      <svg height="20" width="20" style="fill: black;">
+        <use xlink:href="#linkIcon"></use>
+      </svg>
+    </a>
+    <h5 id="<?js=  data.name + '-examples' ?>">Example<?js= examples.length > 1? 's':'' ?></h5>
+    <?js= this.partial('examples.tmpl', examples) ?>
+  </div>
 <?js } ?>


### PR DESCRIPTION
This adds anchor tags and link icons on hover to example blocks. This is not for individual examples, but for just the examples section for each method.

For example, with this change `https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#create-examples` will link to the `.create` examples section.

<img width="483" alt="screen shot 2017-07-27 at 2 28 03 pm" src="https://user-images.githubusercontent.com/7514489/28688657-35fb5b1c-72d8-11e7-8814-7b515f090bd9.png">
