### PR TITLE
Hide hidden modules from members section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+3.1.1
+-----
+- Hide hidden modules from members section
+
 3.1.0
 -----
 - Add anchor tags to examples

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -1,5 +1,6 @@
 <?js
   var self = this;
+  var conf = env.conf;
   var isGlobalPage;
 
   docs.forEach(function(doc, i) {
@@ -147,6 +148,8 @@
 
     <?js
       var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
+      var excludePattern = conf.source.excludePattern;
+      var re = new RegExp(excludePattern);
 
       // symbols that are assigned to module.exports are not globals, even though they're not a memberof anything
       if (isGlobalPage && members && members.length && members.forEach) {
@@ -154,13 +157,15 @@
           return m.longname && m.longname.indexOf('module:') !== 0;
         });
       }
-      
+
       if (members && members.length && members.forEach) {
   ?>
         <h3 class="subsection-title">Members</h3>
 
-        <?js members.forEach(function(p) { ?>
-          <?js= self.partial('members.tmpl', p) ?>
+        <?js members.forEach(function(p) {
+          if (!p.comment.match(re)) { ?>
+            <?js= self.partial('members.tmpl', p) ?>
+          <?js } ?>
         <?js }); ?>
     <?js } ?>
 

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -148,8 +148,7 @@
 
     <?js
       var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
-      var excludePattern = conf.source.excludePattern;
-      var re = new RegExp(excludePattern);
+      var excludePattern = new RegExp(conf.source.excludePattern);
 
       // symbols that are assigned to module.exports are not globals, even though they're not a memberof anything
       if (isGlobalPage && members && members.length && members.forEach) {
@@ -163,7 +162,7 @@
         <h3 class="subsection-title">Members</h3>
 
         <?js members.forEach(function(p) {
-          if (!p.comment.match(re)) { ?>
+          if (!p.comment.match(excludePattern)) { ?>
             <?js= self.partial('members.tmpl', p) ?>
           <?js } ?>
         <?js }); ?>


### PR DESCRIPTION
Right now if you look at the members section of the braintree-web module, it will show hidden modules greyed out. This fix hides them. 