### PR TITLE
jswork will include members and setters even if excludePattern is not set

### DIFF
--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -162,7 +162,7 @@
         <h3 class="subsection-title">Members</h3>
 
         <?js members.forEach(function(p) {
-          if (!p.comment.match(excludePattern)) { ?>
+          if (!conf.source.excludePattern || !p.comment.match(excludePattern)) { ?>
             <?js= self.partial('members.tmpl', p) ?>
           <?js } ?>
         <?js }); ?>


### PR DESCRIPTION
If your config file doesn't have excludePattern, the following line in container.tpl:

    var excludePattern = new RegExp(conf.source.excludePattern);

Creates a blank regexp which then makes this portion impossible to execute:

     <?js members.forEach(function(p) {
          if (!conf.source.excludePattern || !p.comment.match(excludePattern)) { ?>
            <?js= self.partial('members.tmpl', p) ?>
          <?js } ?>
        <?js }); ?>

This PR fixes it by activating the filter ONLY if `conf.source.excludePattern` is set