### PR TITLE
Make list items visible in article

### DIFF
--- a/static/styles/prettify-tomorrow.css
+++ b/static/styles/prettify-tomorrow.css
@@ -105,6 +105,12 @@ pre.prettyprint {
   padding: 10px; }
 */
 
+/* Get LI elements to show when they are in the main article */
+article ul li {
+  list-style-type: circle;
+  margin-left: 25px;
+}
+
 /* Specify class=linenums on a pre to get line numbering */
 ol.linenums {
   margin-top: 0;


### PR DESCRIPTION
At the moment, list items are invisible. That's OK for menus on the left, but it makes it hard to write tutorials and explanations -- especially if you are a big fan of bullet lists!

This simple change makes sure that LIs are visible when in the main article.