### PR TITLE
Enable extra entries in side bar

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -356,11 +356,11 @@ function buildNav(members) {
   nav += buildMemberNav(members.modules, 'Modules', {}, linkto);
     // TODO: as needed, comment back in later
     // nav += buildMemberNav(members.externals, 'Externals', seen, linktoExternal);
-    // nav += buildMemberNav(members.events, 'Events', seen, linkto);
-    // nav += buildMemberNav(members.namespaces, 'Namespaces', seen, linkto);
-    // nav += buildMemberNav(members.mixins, 'Mixins', seen, linkto);
+   nav += buildMemberNav(members.events, 'Events', seen, linkto);
+   nav += buildMemberNav(members.namespaces, 'Namespaces', seen, linkto);
+   nav += buildMemberNav(members.mixins, 'Mixins', seen, linkto);
     // nav += buildMemberNav(members.tutorials, 'Tutorials', seenTutorials, linktoTutorial);
-    // nav += buildMemberNav(members.interfaces, 'Interfaces', seen, linkto);
+   nav += buildMemberNav(members.interfaces, 'Interfaces', seen, linkto);
 
   if (members.globals.length) {
     members.globals.forEach(function (g) {


### PR DESCRIPTION
Some of the entries on the sidebar were commented.
I am not sure why that is... what I do know is that:

* I just couldn't figure out why Mixins (as well as several others) were commented out
*  `nav += buildMemberNav(members.externals, 'Externals', seen, linktoExternal);` and 
    `nav += buildMemberNav(members.tutorials, 'Tutorials', seenTutorials, linktoTutorial);` don't work
    without uncommenting further pieces in the code... so I didn't.

I would have opened an issue about this one, but issues are disabled...
I guess the question is: why are those sections commented out? (Especially Exnternals and Tutorials)

Can I make them optional in the config?