### PR TITLE
Show package version in title

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -206,10 +206,11 @@ function getPathFromDoclet(doclet) {
 
 function generate(type, title, docs, filename, resolveLinks) {
   var packageInfo = (find({kind: 'package'}) || [])[0];
+
   resolveLinks = resolveLinks !== false;
 
   var docData = {
-    package: packageInfo,
+    'package': packageInfo,
     type: type,
     title: title,
     docs: docs

--- a/publish.js
+++ b/publish.js
@@ -205,9 +205,11 @@ function getPathFromDoclet(doclet) {
 }
 
 function generate(type, title, docs, filename, resolveLinks) {
+  var packageInfo = (find({kind: 'package'}) || [])[0];
   resolveLinks = resolveLinks !== false;
 
   var docData = {
+    package: packageInfo,
     type: type,
     title: title,
     docs: docs

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -97,6 +97,7 @@ var resources = templates.resources;
   <nav>
     <h3 class="reference-title">
       <?js= templates.referenceTitle || 'Braintree SDK Client Reference' ?>
+      <?js= package.version ?>
     </h3>
 
     <?js if (resources) { ?>


### PR DESCRIPTION
It took me a long time to figure out how to do this, due to there being no documentation on how to work with jsdoc templates anywhere. I thought perhaps showing the version in the title might be nice, for versioned docs. Thoughts?