### PR TITLE
Add post process function

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -220,6 +220,11 @@ function generate(type, title, docs, filename, resolveLinks) {
     html = helper.resolveLinks(html); // turn {@link foo} into <a href="foodoc.html">foo</a>
   }
 
+  if (env.conf.templates.postProcess
+      && typeof env.conf.templates.postProcess === 'function') {
+    html = env.conf.templates.postProcess(html);
+  }
+
   fs.writeFileSync(outpath, html, 'utf8');
 }
 

--- a/publish.js
+++ b/publish.js
@@ -220,8 +220,7 @@ function generate(type, title, docs, filename, resolveLinks) {
     html = helper.resolveLinks(html); // turn {@link foo} into <a href="foodoc.html">foo</a>
   }
 
-  if (env.conf.templates.postProcess
-      && typeof env.conf.templates.postProcess === 'function') {
+  if (typeof env.conf.templates.postProcess === 'function') {
     html = env.conf.templates.postProcess(html);
   }
 


### PR DESCRIPTION
JSDoc is so template-unaware that there are no events or hooks regarding the actual creation of markup. These three lines would add an option in the config to include a function that processes the content of each html file as it is created.

Example ee cummings config:

```javascript
module.exports = {
  opts: {
    destination: 'out',
    template: 'jsdoc-template'
  },
  source: {
    include: 'src',
  },
  templates: {
    referenceTitle: 'my jsdoc output',
    postProcess: text => text.toString().toLowerCase()
  }
};
```