### PR TITLE
feat(deps): remove taffydb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat(deps): Add conventional commits
 - build(other): Upgrade to Node 18
+- feat(deps): Remove `taffydb`
 
 ## v3.4.0 (2020-10-15)
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ A clean, responsive documentation template with search and navigation highlighti
 
 ## Uses
 
-- [the Taffy Database library](http://taffydb.com/)
+- [JSdoc salty](https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc-salty)
 - [Underscore Template library](http://documentcloud.github.com/underscore/#template)
 - [Algolia DocSearch](https://community.algolia.com/docsearch/)
 
 ## Usage
 
 Clone repository to your designated `jsdoc` template directory, then:
-
 
 ### Node.js Dependency
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
+        "@jsdoc/salty": "^0.2.12",
         "commitizen": "^4.3.1",
         "cz-customizable": "^7.5.4",
         "eslint": "^8.13.0",
         "eslint-config-braintree": "^5.0.1",
-        "husky": "^9.1.7",
-        "taffydb": "^2.7.3"
+        "husky": "^9.1.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -392,6 +392,26 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
+    "node_modules/@jsdoc/salty/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2854,11 +2874,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/taffydb": {
-      "version": "2.7.3",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/temp": {
       "version": "0.9.4",
       "dev": true,
@@ -3320,6 +3335,23 @@
     "@humanwhocodes/object-schema": {
       "version": "2.0.3",
       "dev": true
+    },
+    "@jsdoc/salty": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.18.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.18.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+          "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+          "dev": true
+        }
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4814,10 +4846,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "taffydb": {
-      "version": "2.7.3",
-      "dev": true
     },
     "temp": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
+    "@jsdoc/salty": "^0.2.12",
     "commitizen": "^4.3.1",
     "cz-customizable": "^7.5.4",
     "eslint": "^8.13.0",
     "eslint-config-braintree": "^5.0.1",
-    "husky": "^9.1.7",
-    "taffydb": "^2.7.3"
+    "husky": "^9.1.7"
   },
   "config": {
     "commitizen": {

--- a/publish.js
+++ b/publish.js
@@ -7,7 +7,7 @@ var fs = require('jsdoc/fs');
 var helper = require('jsdoc/util/templateHelper');
 var logger = require('jsdoc/util/logger');
 var path = require('jsdoc/path');
-var taffy = require('taffydb').taffy;
+var taffy = require('@jsdoc/salty').taffy;
 var template = require('jsdoc/template');
 var util = require('util');
 
@@ -387,6 +387,7 @@ function buildNav(members) {
 }
 
 /**
+    technically taffyDB object, but we use `@jsdoc/salty` to pull into database form
     @param {TAFFY} taffyData See <http://taffydb.com/>.
     @param {object} opts
     @param {Tutorial} tutorials


### PR DESCRIPTION
# Summary of changes

TAFFYDB IS DEAD!

big [CVN vuln](https://www.cve.org/CVERecord?id=CVE-2019-10790) in taffydb means we should not use it with our jsdocs! thankfully, @hegemonic built out a smaller module, [`@jsdoc/salty`](https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc-salty) that does that for us!

tested by running our jsdoc generation in our parent internal repo against the new publish workflow powered by taffydb, and ensuring docs were able to be generated!

## Checklist

- [X] Added a changelog entry
- [ ] Relevant test coverage
- [X] Tested and confirmed flows affected by this change are functioning as expected

## Authors
>
> @adrmachado-public 

### Reviewers

@braintree/team-sdk-js
